### PR TITLE
fix(typeCast): ensure the same behavior for `field.string()` with `query` and `execute`

### DIFF
--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -102,6 +102,24 @@ function compile(fields, options, config) {
           );
         }
 
+        if (
+          [Types.DATETIME, Types.NEWDATE, Types.TIMESTAMP, Types.DATE].includes(
+            field.columnType,
+          )
+        ) {
+          return packet.readDateTimeString(parseInt(field.decimals, 10));
+        }
+
+        if (field.columnType === Types.TINY) {
+          const unsigned = field.flags & FieldFlags.UNSIGNED;
+
+          return String(unsigned ? packet.readInt8() : packet.readSInt8());
+        }
+
+        if (field.columnType === Types.TIME) {
+          return packet.readTimeString();
+        }
+
         return packet.readLengthCodedString(encoding);
       },
       buffer: function () {

--- a/test/esm/integration/parsers/typecast-field-string.test.mjs
+++ b/test/esm/integration/parsers/typecast-field-string.test.mjs
@@ -1,0 +1,57 @@
+import { describe, assert } from 'poku';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
+
+const conn = createConnection({
+  typeCast: (field) => field.string(),
+}).promise();
+
+describe('typeCast field.string', describeOptions);
+
+const query = new Map();
+const execute = new Map();
+
+await conn.query(
+  'CREATE TEMPORARY TABLE tmp_tiny (`tiny` TINYINT, `tinyUnsigned` TINYINT UNSIGNED)',
+);
+await conn.query(
+  'CREATE TEMPORARY TABLE tmp_date (`timestamp` TIMESTAMP, `time` TIME)',
+);
+
+await conn.query('INSERT INTO tmp_tiny (`tiny`, `tinyUnsigned`) VALUES (0, 1)');
+await conn.query(
+  'INSERT INTO tmp_date (`timestamp`, `time`) VALUES (CURRENT_TIMESTAMP(), CURTIME())',
+);
+
+{
+  const [date] = await conn.query('SELECT NOW() AS `now`');
+  const [time] = await conn.query('SELECT timestamp, time FROM tmp_date');
+  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+
+  query.set('date', date[0]);
+  query.set('time', time[0]);
+  query.set('tiny', tinyint[0]);
+}
+
+{
+  const [date] = await conn.execute('SELECT NOW() AS `now`');
+  const [time] = await conn.execute('SELECT timestamp, time FROM tmp_date');
+  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+
+  execute.set('date', date[0]);
+  execute.set('time', time[0]);
+  execute.set('tiny', tinyint[0]);
+}
+
+await conn.end();
+
+assert.deepStrictEqual(
+  query,
+  execute,
+  'Ensures the same behavior for field.string',
+);

--- a/test/esm/integration/parsers/typecast-field-string.test.mjs
+++ b/test/esm/integration/parsers/typecast-field-string.test.mjs
@@ -13,45 +13,72 @@ const conn = createConnection({
 
 describe('typeCast field.string', describeOptions);
 
-const query = new Map();
-const execute = new Map();
+const query = {};
+const execute = {};
 
 await conn.query(
-  'CREATE TEMPORARY TABLE tmp_tiny (`tiny` TINYINT, `tinyUnsigned` TINYINT UNSIGNED)',
+  'CREATE TEMPORARY TABLE `tmp_tiny` (`signed` TINYINT, `unsigned` TINYINT UNSIGNED)',
 );
-await conn.query(
-  'CREATE TEMPORARY TABLE tmp_date (`timestamp` TIMESTAMP, `time` TIME)',
-);
+await conn.query('CREATE TEMPORARY TABLE `tmp_date` (`timestamp` TIMESTAMP)');
 
-await conn.query('INSERT INTO tmp_tiny (`tiny`, `tinyUnsigned`) VALUES (0, 1)');
+await conn.query('INSERT INTO `tmp_tiny` (`signed`, `unsigned`) VALUES (0, 1)');
 await conn.query(
-  'INSERT INTO tmp_date (`timestamp`, `time`) VALUES (CURRENT_TIMESTAMP(), CURTIME())',
+  'INSERT INTO `tmp_date` (`timestamp`) VALUES (CURRENT_TIMESTAMP())',
 );
 
 {
-  const [date] = await conn.query('SELECT NOW() AS `now`');
-  const [time] = await conn.query('SELECT timestamp, time FROM tmp_date');
-  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+  const [date] = await conn.query(
+    'SELECT STR_TO_DATE("2022-06-28", "%Y-%m-%d") AS `date`',
+  );
+  const [time] = await conn.query(
+    'SELECT STR_TO_DATE("12:34:56", "%H:%i:%s") AS `time`',
+  );
+  const [datetime] = await conn.query(
+    'SELECT STR_TO_DATE("2022-06-28 12:34:56", "%Y-%m-%d %H:%i:%s") AS `datetime`',
+  );
+  const [timestamp] = await conn.query('SELECT `timestamp` FROM `tmp_date`');
+  const [tiny] = await conn.query(
+    'SELECT `signed`, `unsigned` FROM `tmp_tiny`',
+  );
 
-  query.set('date', date[0]);
-  query.set('time', time[0]);
-  query.set('tiny', tinyint[0]);
+  query.date = date[0].date;
+  query.time = time[0].time;
+  query.timestamp = timestamp[0].timestamp;
+  query.datetime = datetime[0].datetime;
+  query.tiny = tiny[0];
 }
 
 {
-  const [date] = await conn.execute('SELECT NOW() AS `now`');
-  const [time] = await conn.execute('SELECT timestamp, time FROM tmp_date');
-  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+  const [date] = await conn.execute(
+    'SELECT STR_TO_DATE("2022-06-28", "%Y-%m-%d") AS `date`',
+  );
+  const [time] = await conn.execute(
+    'SELECT STR_TO_DATE("12:34:56", "%H:%i:%s") AS `time`',
+  );
+  const [datetime] = await conn.execute(
+    'SELECT STR_TO_DATE("2022-06-28 12:34:56", "%Y-%m-%d %H:%i:%s") AS `datetime`',
+  );
+  const [timestamp] = await conn.execute('SELECT `timestamp` FROM `tmp_date`');
+  const [tiny] = await conn.execute(
+    'SELECT `signed`, `unsigned` FROM `tmp_tiny`',
+  );
 
-  execute.set('date', date[0]);
-  execute.set('time', time[0]);
-  execute.set('tiny', tinyint[0]);
+  execute.date = date[0].date;
+  execute.time = time[0].time;
+  execute.timestamp = timestamp[0].timestamp;
+  execute.datetime = datetime[0].datetime;
+  execute.tiny = tiny[0];
 }
 
 await conn.end();
 
+assert.deepStrictEqual(query.date, execute.date, 'DATE');
+assert.deepStrictEqual(query.time, execute.time, 'TIME');
+assert.deepStrictEqual(query.datetime, execute.datetime, 'DATETIME');
+assert.deepStrictEqual(query.timestamp, execute.timestamp, 'TIMESTAMP');
+assert.deepStrictEqual(query.tiny.signed, execute.tiny.signed, 'TINY (signed)');
 assert.deepStrictEqual(
-  query,
-  execute,
-  'Ensures the same behavior for field.string',
+  query.tiny.unsigned,
+  execute.tiny.unsigned,
+  'TINY (unsigned)',
 );


### PR DESCRIPTION
> Debugging