### PR TITLE
ci: resolve Promise wrapper flaky test

### DIFF
--- a/test/integration/promise-wrappers/test-promise-wrappers.test.cjs
+++ b/test/integration/promise-wrappers/test-promise-wrappers.test.cjs
@@ -207,18 +207,13 @@ function testEventsConnect() {
 
 function testBasicPool() {
   const pool = createPool(config);
-  const promiseConn = pool.getConnection();
-
-  promiseConn
-    .then((connResolved) => {
-      pool.releaseConnection(connResolved);
-    })
-    .catch((err) => {
-      throw err;
-    });
 
   pool
-    .query('select 1+2 as ttt')
+    .getConnection()
+    .then((connResolved) => {
+      pool.releaseConnection(connResolved);
+      return pool.query('select 1+2 as ttt');
+    })
     .then((result1) => {
       assert.equal(result1[0][0].ttt, 3);
       return pool.query('select 2+2 as qqq');


### PR DESCRIPTION
Occasionally, the `test-promise-wrappers.test.cjs` test can fail if:

```js
.then((result2) => {
  assert.equal(result2[0][0].qqq, 4);
  return pool.end();
})
```

is executed before:

```js
.then((connResolved) => {
  pool.releaseConnection(connResolved);
})
```

This _PR_  ensures the execution order is respected, fixing the flaky test in the `Promise` wrappers.

---

A failure example:

<img width="642" height="864" alt="Screenshot 2025-09-23 at 16 35 07" src="https://github.com/user-attachments/assets/5ca18760-824f-4827-a701-bf8be8cc6dbe" />
